### PR TITLE
Fix issue with leading zeroes in AES256CBC

### DIFF
--- a/src/main/java/org/torusresearch/torusutils/helpers/AES256CBC.java
+++ b/src/main/java/org/torusresearch/torusutils/helpers/AES256CBC.java
@@ -15,14 +15,14 @@ import java.util.Arrays;
 
 public class AES256CBC {
     private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
-    private final BigInteger AES_ENCRYPTION_KEY;
-    private final BigInteger ENCRYPTION_IV;
+    private final byte[] AES_ENCRYPTION_KEY;
+    private final byte[] ENCRYPTION_IV;
 
     public AES256CBC(String privateKeyHex, String ephemPublicKeyHex, String encryptionIvHex) throws NoSuchAlgorithmException {
         byte[] hash = SHA512.digest(toByteArray(ecdh(privateKeyHex, ephemPublicKeyHex)));
         byte[] encKeyBytes = Arrays.copyOfRange(hash, 0, 32);
-        AES_ENCRYPTION_KEY = new BigInteger(encKeyBytes);
-        ENCRYPTION_IV = new BigInteger(encryptionIvHex, 16);
+        AES_ENCRYPTION_KEY = encKeyBytes;
+        ENCRYPTION_IV = toByteArray(encryptionIvHex);
     }
 
     /**
@@ -40,6 +40,16 @@ public class AES256CBC {
             b = newArray;
         }
         return b;
+    }
+
+    public static byte[] toByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
     }
 
     public String encrypt(byte[] src) throws TorusException {
@@ -79,10 +89,10 @@ public class AES256CBC {
     }
 
     private Key makeKey() {
-        return new SecretKeySpec(toByteArray(AES_ENCRYPTION_KEY), "AES");
+        return new SecretKeySpec(AES_ENCRYPTION_KEY, "AES");
     }
 
     private AlgorithmParameterSpec makeIv() {
-        return new IvParameterSpec(toByteArray(ENCRYPTION_IV));
+        return new IvParameterSpec(ENCRYPTION_IV);
     }
 }

--- a/src/test/java/org/torusresearch/torusutilstest/helpers/AES256CBC.java
+++ b/src/test/java/org/torusresearch/torusutilstest/helpers/AES256CBC.java
@@ -1,0 +1,34 @@
+package org.torusresearch.torusutilstest.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AES256CBC {
+
+    @Test
+    public void testLeadingZeroes() {
+        // This combination of private and public keys resuts in an SHA512 hash with a leading zero
+        String privateKey = "dec95a4ffa406daedd079956f1e43fb91baefdad00990699642474eeb09a5a90";
+        String publicKey  = "a6262a5650a9666195098c2e15e8eb451a755eb59ea2d1b437d11d9113f4d356bd479f01d29850b77fa6357628d2ed0fa0d8230620472b91f21db1c2c6e7def";
+
+        // Leading zeroes in IV
+        String iv = "0023456789ABCDEF0123456789ABCDEF";
+
+        byte[] payload = "Hello World".getBytes(StandardCharsets.UTF_8);
+
+        try {
+            org.torusresearch.torusutils.helpers.AES256CBC aes256cbc = new org.torusresearch.torusutils.helpers.AES256CBC(privateKey, publicKey, iv);
+            String encrypted = aes256cbc.encrypt(payload);
+            byte[] decrypted = aes256cbc.decrypt(encrypted);
+
+            assertArrayEquals(payload, decrypted);
+        } catch (Exception e) {
+            assertFalse(true);
+        }
+    }
+
+
+}


### PR DESCRIPTION
The AES256CBC class stored  encryption keys and the initialization vector as `BigInteger` this resulted in leading zeroes being dropped while converted back to a byte array, this fix stores them directly as `byte[]` to avoid the issue.

A test is included with a combination of private and public keys that shows the the consequences of the leading zeroes being dropped.

